### PR TITLE
Removing setERC20Metadata function and adding it to Initializer

### DIFF
--- a/contracts/moonstream/ERC20Initializer.sol
+++ b/contracts/moonstream/ERC20Initializer.sol
@@ -15,13 +15,13 @@ import "../diamond/libraries/LibDiamond.sol";
 import "./LibERC20.sol";
 
 contract ERC20Initializer {
-    function init() external {
+    function init(string memory name, string memory symbol) external {
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
         ds.supportedInterfaces[type(IERC20).interfaceId] = true;
 
         LibERC20.ERC20Storage storage es = LibERC20.erc20Storage();
         es.controller = msg.sender;
-        es.name = "Moonstream DAO";
-        es.symbol = "MNSTR";
+        es.name = name;
+        es.symbol = symbol;
     }
 }

--- a/contracts/moonstream/ERC20WithCommonStorage.sol
+++ b/contracts/moonstream/ERC20WithCommonStorage.sol
@@ -24,24 +24,6 @@ import "./LibERC20.sol";
 
 contract ERC20WithCommonStorage is Context, IERC20, IERC20Metadata {
     /**
-     * @dev Sets the values for {name} and {symbol}.
-     *
-     * The default value of {decimals} is 18. To select a different value for
-     * {decimals} you should overload it.
-     *
-     * All two of these values are immutable: they can only be set once during
-     * construction.
-     */
-    function setERC20Metadata(string memory name_, string memory symbol_)
-        external
-    {
-        LibERC20.enforceIsController();
-        LibERC20.ERC20Storage storage es = LibERC20.erc20Storage();
-        es.name = name_;
-        es.symbol = symbol_;
-    }
-
-    /**
      * @dev Returns the name of the token.
      */
     function name() public view virtual override returns (string memory) {

--- a/dao/core.py
+++ b/dao/core.py
@@ -54,6 +54,7 @@ def facet_cut(
     ignore_selectors: Optional[List[str]] = None,
     methods: Optional[List[str]] = None,
     selectors: Optional[List[str]] = None,
+    initializer_params: Optional[List[Any]] = None,
 ) -> Any:
     """
     Cuts the given facet onto the given Diamond contract.
@@ -127,7 +128,7 @@ def facet_cut(
     if facet_name == "ERC20Facet":
         if initializer_address != ZERO_ADDRESS and action != "remove":
             erc20_initializer = ERC20Initializer.ERC20Initializer(initializer_address)
-            calldata = erc20_initializer.contract.init.encode_input()
+            calldata = erc20_initializer.contract.init.encode_input(initializer_params[0], initializer_params[1])
     elif facet_name == "TerminusFacet":
         if initializer_address != ZERO_ADDRESS and action != "remove":
             terminus_initializer = TerminusInitializer.TerminusInitializer(

--- a/dao/test_core.py
+++ b/dao/test_core.py
@@ -39,6 +39,7 @@ class MoonstreamTokenTestCase(MoonstreamDAOSingleContractTestCase):
             "add",
             {"from": accounts[0]},
             initializer.address,
+            initializer_params = ["Moonstream DAO", "MNSTR"]
         )
 
         cls.erc20_initializer = initializer.address

--- a/dao/test_moonstream.py
+++ b/dao/test_moonstream.py
@@ -24,6 +24,7 @@ class TestDeployment(MoonstreamDAOSingleContractTestCase):
             "add",
             {"from": accounts[0]},
             initializer.address,
+            initializer_params = ["Moonstream DAO", "MNSTR"]
         )
 
         diamond_erc20 = ERC20Facet.ERC20Facet(diamond_address)
@@ -39,19 +40,6 @@ class TestDeployment(MoonstreamDAOSingleContractTestCase):
         expected_decimals = 18
         self.assertEqual(decimals, expected_decimals)
 
-        with self.assertRaises(Exception):
-            diamond_erc20.set_erc20_metadata("LOL", "ROFL", {"from": accounts[1]})
-
-        diamond_erc20.set_erc20_metadata("LOL", "ROFL", {"from": accounts[0]})
-
-        name = diamond_erc20.name()
-        expected_name = "LOL"
-        self.assertEqual(name, expected_name)
-
-        symbol = diamond_erc20.symbol()
-        expected_symbol = "ROFL"
-        self.assertEqual(symbol, expected_symbol)
-
         new_erc20_facet = ERC20Facet.ERC20Facet(None)
         new_erc20_facet.deploy({"from": accounts[0]})
         facet_cut(
@@ -61,14 +49,15 @@ class TestDeployment(MoonstreamDAOSingleContractTestCase):
             "replace",
             {"from": accounts[0]},
             initializer.address,
+            initializer_params = ["ROFL", "LOL"]
         )
 
         name = diamond_erc20.name()
-        expected_name = "Moonstream DAO"
+        expected_name = "ROFL"
         self.assertEqual(name, expected_name)
 
         symbol = diamond_erc20.symbol()
-        expected_symbol = "MNSTR"
+        expected_symbol = "LOL"
         self.assertEqual(symbol, expected_symbol)
 
 
@@ -88,6 +77,7 @@ class TestRemoveFacet(MoonstreamDAOSingleContractTestCase):
             "add",
             {"from": accounts[0]},
             initializer.address,
+            initializer_params = ["Moonstream DAO", "MNSTR"]
         )
 
         diamond_erc20 = ERC20Facet.ERC20Facet(diamond_address)


### PR DESCRIPTION
## Changes

In order to be compliant with exchanges we need symbol and name to be fixed. So that's why instead of having a default symbol MNSTR and name Moonstream DAO. The values are provided to the initializer to do that an optional parameter `initializer_params` was added to the `facet_cut` function.

## How to test these changes?
 
test_moonstream has been modified in order to check that everything is working properly.
