### PR TITLE
Terminus pool approval improvements

### DIFF
--- a/contracts/terminus/ERC1155WithTerminusStorage.sol
+++ b/contracts/terminus/ERC1155WithTerminusStorage.sol
@@ -148,6 +148,11 @@ contract ERC1155WithTerminusStorage is
         LibTerminus._approveForPool(poolID, operator);
     }
 
+    function unapproveForPool(uint256 poolID, address operator) external {
+        LibTerminus.enforcePoolIsController(poolID, _msgSender());
+        LibTerminus._unapproveForPool(poolID, operator);
+    }
+
     /**
      * @dev See {IERC1155-safeTransferFrom}.
      */

--- a/contracts/terminus/LibTerminus.sol
+++ b/contracts/terminus/LibTerminus.sol
@@ -123,4 +123,9 @@ library LibTerminus {
         LibTerminus.TerminusStorage storage ts = LibTerminus.terminusStorage();
         ts.globalPoolOperatorApprovals[poolID][operator] = true;
     }
+
+    function _unapproveForPool(uint256 poolID, address operator) internal {
+        LibTerminus.TerminusStorage storage ts = LibTerminus.terminusStorage();
+        ts.globalPoolOperatorApprovals[poolID][operator] = false;
+    }
 }

--- a/contracts/terminus/controller/TerminusControllerFacet.sol
+++ b/contracts/terminus/controller/TerminusControllerFacet.sol
@@ -192,6 +192,20 @@ contract TerminusControllerFacet is TerminusPermissions, TokenDrainerFacet {
         return terminusContract().terminusPoolSupply(poolID);
     }
 
+    function approveForPool(uint256 poolID, address operator)
+        external
+        onlyMainAdmin
+    {
+        terminusContract().approveForPool(poolID, operator);
+    }
+
+    function unapproveForPool(uint256 poolID, address operator)
+        external
+        onlyMainAdmin
+    {
+        terminusContract().unapproveForPool(poolID, operator);
+    }
+
     function _approvePoolCreationPayments() internal {
         IERC20 paymentToken = IERC20(terminusContract().paymentToken());
         uint256 fee = terminusContract().poolBasePrice();

--- a/contracts/terminus/controller/TerminusControllerFacet.sol
+++ b/contracts/terminus/controller/TerminusControllerFacet.sol
@@ -202,14 +202,14 @@ contract TerminusControllerFacet is TerminusPermissions, TokenDrainerFacet {
 
     function approveForPool(uint256 poolID, address operator)
         external
-        onlyMainAdmin
+        onlyPoolController(poolID)
     {
         terminusContract().approveForPool(poolID, operator);
     }
 
     function unapproveForPool(uint256 poolID, address operator)
         external
-        onlyMainAdmin
+        onlyPoolController(poolID)
     {
         terminusContract().unapproveForPool(poolID, operator);
     }

--- a/contracts/terminus/controller/TerminusControllerFacet.sol
+++ b/contracts/terminus/controller/TerminusControllerFacet.sol
@@ -192,6 +192,14 @@ contract TerminusControllerFacet is TerminusPermissions, TokenDrainerFacet {
         return terminusContract().terminusPoolSupply(poolID);
     }
 
+    function isApprovedForPool(uint256 poolID, address operator)
+        public
+        view
+        returns (bool)
+    {
+        return terminusContract().isApprovedForPool(poolID, operator);
+    }
+
     function approveForPool(uint256 poolID, address operator)
         external
         onlyMainAdmin

--- a/dao/TerminusControllerFacet.py
+++ b/dao/TerminusControllerFacet.py
@@ -96,6 +96,12 @@ class TerminusControllerFacet:
         contract_class = contract_from_build(self.contract_name)
         contract_class.publish_source(self.contract)
 
+    def approve_for_pool(
+        self, pool_id: int, operator: ChecksumAddress, transaction_config
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.approveForPool(pool_id, operator, transaction_config)
+
     def balance_of(
         self,
         account: ChecksumAddress,
@@ -126,6 +132,29 @@ class TerminusControllerFacet:
     def create_simple_pool(self, _capacity: int, transaction_config) -> Any:
         self.assert_contract_is_instantiated()
         return self.contract.createSimplePool(_capacity, transaction_config)
+
+    def drain_erc1155(
+        self,
+        token_address: ChecksumAddress,
+        token_id: int,
+        receiver_address: ChecksumAddress,
+        transaction_config,
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.drainERC1155(
+            token_address, token_id, receiver_address, transaction_config
+        )
+
+    def drain_erc20(
+        self,
+        token_address: ChecksumAddress,
+        receiver_address: ChecksumAddress,
+        transaction_config,
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.drainERC20(
+            token_address, receiver_address, transaction_config
+        )
 
     def get_terminus_address(
         self, block_number: Optional[Union[str, int]] = "latest"
@@ -162,6 +191,17 @@ class TerminusControllerFacet:
             _terminus_main_admin_pool_terminus_address,
             _terminus_main_admin_pool_id,
             transaction_config,
+        )
+
+    def is_approved_for_pool(
+        self,
+        pool_id: int,
+        operator: ChecksumAddress,
+        block_number: Optional[Union[str, int]] = "latest",
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.isApprovedForPool.call(
+            pool_id, operator, block_identifier=block_number
         )
 
     def mint(
@@ -262,6 +302,37 @@ class TerminusControllerFacet:
         self.assert_contract_is_instantiated()
         return self.contract.totalPools.call(block_identifier=block_number)
 
+    def unapprove_for_pool(
+        self, pool_id: int, operator: ChecksumAddress, transaction_config
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.unapproveForPool(pool_id, operator, transaction_config)
+
+    def withdraw_erc1155(
+        self,
+        token_address: ChecksumAddress,
+        token_id: int,
+        amount: int,
+        receiver_address: ChecksumAddress,
+        transaction_config,
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.withdrawERC1155(
+            token_address, token_id, amount, receiver_address, transaction_config
+        )
+
+    def withdraw_erc20(
+        self,
+        token_address: ChecksumAddress,
+        amount: int,
+        receiver_address: ChecksumAddress,
+        transaction_config,
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.withdrawERC20(
+            token_address, amount, receiver_address, transaction_config
+        )
+
 
 def get_transaction_config(args: argparse.Namespace) -> Dict[str, Any]:
     signer = network.accounts.load(args.sender, args.password)
@@ -347,6 +418,20 @@ def handle_verify_contract(args: argparse.Namespace) -> None:
     print(result)
 
 
+def handle_approve_for_pool(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusControllerFacet(args.address)
+    transaction_config = get_transaction_config(args)
+    result = contract.approve_for_pool(
+        pool_id=args.pool_id,
+        operator=args.operator,
+        transaction_config=transaction_config,
+    )
+    print(result)
+    if args.verbose:
+        print(result.info())
+
+
 def handle_balance_of(args: argparse.Namespace) -> None:
     network.connect(args.network)
     contract = TerminusControllerFacet(args.address)
@@ -405,6 +490,35 @@ def handle_create_simple_pool(args: argparse.Namespace) -> None:
         print(result.info())
 
 
+def handle_drain_erc1155(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusControllerFacet(args.address)
+    transaction_config = get_transaction_config(args)
+    result = contract.drain_erc1155(
+        token_address=args.token_address,
+        token_id=args.token_id,
+        receiver_address=args.receiver_address,
+        transaction_config=transaction_config,
+    )
+    print(result)
+    if args.verbose:
+        print(result.info())
+
+
+def handle_drain_erc20(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusControllerFacet(args.address)
+    transaction_config = get_transaction_config(args)
+    result = contract.drain_erc20(
+        token_address=args.token_address,
+        receiver_address=args.receiver_address,
+        transaction_config=transaction_config,
+    )
+    print(result)
+    if args.verbose:
+        print(result.info())
+
+
 def handle_get_terminus_address(args: argparse.Namespace) -> None:
     network.connect(args.network)
     contract = TerminusControllerFacet(args.address)
@@ -441,6 +555,15 @@ def handle_init_terminus_controller(args: argparse.Namespace) -> None:
     print(result)
     if args.verbose:
         print(result.info())
+
+
+def handle_is_approved_for_pool(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusControllerFacet(args.address)
+    result = contract.is_approved_for_pool(
+        pool_id=args.pool_id, operator=args.operator, block_number=args.block_number
+    )
+    print(result)
 
 
 def handle_mint(args: argparse.Namespace) -> None:
@@ -598,6 +721,51 @@ def handle_total_pools(args: argparse.Namespace) -> None:
     print(result)
 
 
+def handle_unapprove_for_pool(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusControllerFacet(args.address)
+    transaction_config = get_transaction_config(args)
+    result = contract.unapprove_for_pool(
+        pool_id=args.pool_id,
+        operator=args.operator,
+        transaction_config=transaction_config,
+    )
+    print(result)
+    if args.verbose:
+        print(result.info())
+
+
+def handle_withdraw_erc1155(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusControllerFacet(args.address)
+    transaction_config = get_transaction_config(args)
+    result = contract.withdraw_erc1155(
+        token_address=args.token_address,
+        token_id=args.token_id,
+        amount=args.amount,
+        receiver_address=args.receiver_address,
+        transaction_config=transaction_config,
+    )
+    print(result)
+    if args.verbose:
+        print(result.info())
+
+
+def handle_withdraw_erc20(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusControllerFacet(args.address)
+    transaction_config = get_transaction_config(args)
+    result = contract.withdraw_erc20(
+        token_address=args.token_address,
+        amount=args.amount,
+        receiver_address=args.receiver_address,
+        transaction_config=transaction_config,
+    )
+    print(result)
+    if args.verbose:
+        print(result.info())
+
+
 def generate_cli() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="CLI for TerminusControllerFacet")
     parser.set_defaults(func=lambda _: parser.print_help())
@@ -610,6 +778,16 @@ def generate_cli() -> argparse.ArgumentParser:
     verify_contract_parser = subcommands.add_parser("verify-contract")
     add_default_arguments(verify_contract_parser, False)
     verify_contract_parser.set_defaults(func=handle_verify_contract)
+
+    approve_for_pool_parser = subcommands.add_parser("approve-for-pool")
+    add_default_arguments(approve_for_pool_parser, True)
+    approve_for_pool_parser.add_argument(
+        "--pool-id", required=True, help="Type: uint256", type=int
+    )
+    approve_for_pool_parser.add_argument(
+        "--operator", required=True, help="Type: address"
+    )
+    approve_for_pool_parser.set_defaults(func=handle_approve_for_pool)
 
     balance_of_parser = subcommands.add_parser("balance-of")
     add_default_arguments(balance_of_parser, False)
@@ -653,6 +831,29 @@ def generate_cli() -> argparse.ArgumentParser:
     )
     create_simple_pool_parser.set_defaults(func=handle_create_simple_pool)
 
+    drain_erc1155_parser = subcommands.add_parser("drain-erc1155")
+    add_default_arguments(drain_erc1155_parser, True)
+    drain_erc1155_parser.add_argument(
+        "--token-address", required=True, help="Type: address"
+    )
+    drain_erc1155_parser.add_argument(
+        "--token-id", required=True, help="Type: uint256", type=int
+    )
+    drain_erc1155_parser.add_argument(
+        "--receiver-address", required=True, help="Type: address"
+    )
+    drain_erc1155_parser.set_defaults(func=handle_drain_erc1155)
+
+    drain_erc20_parser = subcommands.add_parser("drain-erc20")
+    add_default_arguments(drain_erc20_parser, True)
+    drain_erc20_parser.add_argument(
+        "--token-address", required=True, help="Type: address"
+    )
+    drain_erc20_parser.add_argument(
+        "--receiver-address", required=True, help="Type: address"
+    )
+    drain_erc20_parser.set_defaults(func=handle_drain_erc20)
+
     get_terminus_address_parser = subcommands.add_parser("get-terminus-address")
     add_default_arguments(get_terminus_address_parser, False)
     get_terminus_address_parser.set_defaults(func=handle_get_terminus_address)
@@ -693,6 +894,16 @@ def generate_cli() -> argparse.ArgumentParser:
         type=int,
     )
     init_terminus_controller_parser.set_defaults(func=handle_init_terminus_controller)
+
+    is_approved_for_pool_parser = subcommands.add_parser("is-approved-for-pool")
+    add_default_arguments(is_approved_for_pool_parser, False)
+    is_approved_for_pool_parser.add_argument(
+        "--pool-id", required=True, help="Type: uint256", type=int
+    )
+    is_approved_for_pool_parser.add_argument(
+        "--operator", required=True, help="Type: address"
+    )
+    is_approved_for_pool_parser.set_defaults(func=handle_is_approved_for_pool)
 
     mint_parser = subcommands.add_parser("mint")
     add_default_arguments(mint_parser, True)
@@ -810,6 +1021,45 @@ def generate_cli() -> argparse.ArgumentParser:
     total_pools_parser = subcommands.add_parser("total-pools")
     add_default_arguments(total_pools_parser, False)
     total_pools_parser.set_defaults(func=handle_total_pools)
+
+    unapprove_for_pool_parser = subcommands.add_parser("unapprove-for-pool")
+    add_default_arguments(unapprove_for_pool_parser, True)
+    unapprove_for_pool_parser.add_argument(
+        "--pool-id", required=True, help="Type: uint256", type=int
+    )
+    unapprove_for_pool_parser.add_argument(
+        "--operator", required=True, help="Type: address"
+    )
+    unapprove_for_pool_parser.set_defaults(func=handle_unapprove_for_pool)
+
+    withdraw_erc1155_parser = subcommands.add_parser("withdraw-erc1155")
+    add_default_arguments(withdraw_erc1155_parser, True)
+    withdraw_erc1155_parser.add_argument(
+        "--token-address", required=True, help="Type: address"
+    )
+    withdraw_erc1155_parser.add_argument(
+        "--token-id", required=True, help="Type: uint256", type=int
+    )
+    withdraw_erc1155_parser.add_argument(
+        "--amount", required=True, help="Type: uint256", type=int
+    )
+    withdraw_erc1155_parser.add_argument(
+        "--receiver-address", required=True, help="Type: address"
+    )
+    withdraw_erc1155_parser.set_defaults(func=handle_withdraw_erc1155)
+
+    withdraw_erc20_parser = subcommands.add_parser("withdraw-erc20")
+    add_default_arguments(withdraw_erc20_parser, True)
+    withdraw_erc20_parser.add_argument(
+        "--token-address", required=True, help="Type: address"
+    )
+    withdraw_erc20_parser.add_argument(
+        "--amount", required=True, help="Type: uint256", type=int
+    )
+    withdraw_erc20_parser.add_argument(
+        "--receiver-address", required=True, help="Type: address"
+    )
+    withdraw_erc20_parser.set_defaults(func=handle_withdraw_erc20)
 
     return parser
 

--- a/dao/TerminusFacet.py
+++ b/dao/TerminusFacet.py
@@ -342,6 +342,12 @@ class TerminusFacet:
         self.assert_contract_is_instantiated()
         return self.contract.totalPools.call(block_identifier=block_number)
 
+    def unapprove_for_pool(
+        self, pool_id: int, operator: ChecksumAddress, transaction_config
+    ) -> Any:
+        self.assert_contract_is_instantiated()
+        return self.contract.unapproveForPool(pool_id, operator, transaction_config)
+
     def uri(
         self, pool_id: int, block_number: Optional[Union[str, int]] = "latest"
     ) -> Any:
@@ -819,6 +825,20 @@ def handle_total_pools(args: argparse.Namespace) -> None:
     print(result)
 
 
+def handle_unapprove_for_pool(args: argparse.Namespace) -> None:
+    network.connect(args.network)
+    contract = TerminusFacet(args.address)
+    transaction_config = get_transaction_config(args)
+    result = contract.unapprove_for_pool(
+        pool_id=args.pool_id,
+        operator=args.operator,
+        transaction_config=transaction_config,
+    )
+    print(result)
+    if args.verbose:
+        print(result.info())
+
+
 def handle_uri(args: argparse.Namespace) -> None:
     network.connect(args.network)
     contract = TerminusFacet(args.address)
@@ -1143,6 +1163,16 @@ def generate_cli() -> argparse.ArgumentParser:
     total_pools_parser = subcommands.add_parser("total-pools")
     add_default_arguments(total_pools_parser, False)
     total_pools_parser.set_defaults(func=handle_total_pools)
+
+    unapprove_for_pool_parser = subcommands.add_parser("unapprove-for-pool")
+    add_default_arguments(unapprove_for_pool_parser, True)
+    unapprove_for_pool_parser.add_argument(
+        "--pool-id", required=True, help="Type: uint256", type=int
+    )
+    unapprove_for_pool_parser.add_argument(
+        "--operator", required=True, help="Type: address"
+    )
+    unapprove_for_pool_parser.set_defaults(func=handle_unapprove_for_pool)
 
     uri_parser = subcommands.add_parser("uri")
     add_default_arguments(uri_parser, False)

--- a/dao/test_terminus.py
+++ b/dao/test_terminus.py
@@ -766,7 +766,9 @@ class TestPoolOperations(TerminusTestCase):
         operator_balance_0 = self.diamond_terminus.balance_of(operator.address, pool_id)
         user_balance_0 = self.diamond_terminus.balance_of(user.address, pool_id)
 
-        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
+        self.assertFalse(
+            self.diamond_terminus.is_approved_for_pool(pool_id, operator.address)
+        )
 
         with self.assertRaises(VirtualMachineError):
             self.diamond_terminus.mint(
@@ -818,7 +820,9 @@ class TestPoolOperations(TerminusTestCase):
 
         self.diamond_terminus.approve_for_pool(pool_id, operator, {"from": accounts[1]})
 
-        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
+        self.assertTrue(
+            self.diamond_terminus.is_approved_for_pool(pool_id, operator.address)
+        )
 
         self.diamond_terminus.mint(
             controller.address, pool_id, 1, "", {"from": operator}
@@ -855,13 +859,17 @@ class TestPoolOperations(TerminusTestCase):
                 pool_id, operator, {"from": operator}
             )
 
-        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
+        self.assertTrue(
+            self.diamond_terminus.is_approved_for_pool(pool_id, operator.address)
+        )
 
         self.diamond_terminus.unapprove_for_pool(
             pool_id, operator, {"from": controller}
         )
 
-        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
+        self.assertFalse(
+            self.diamond_terminus.is_approved_for_pool(pool_id, operator.address)
+        )
 
         with self.assertRaises(VirtualMachineError):
             self.diamond_terminus.mint(

--- a/dao/test_terminus.py
+++ b/dao/test_terminus.py
@@ -743,6 +743,13 @@ class TestPoolOperations(TerminusTestCase):
         operator = accounts[2]
         user = accounts[3]
 
+        # TODO(zomglings): We should test the Terminus controller permissions on the same contract.
+        # Currently, controller is both pool controller AND Terminus controller. In a more proper test,
+        # these would be different accounts.
+
+        # TODO(zomglings): Tested manually that changing burnable below from True to False results in
+        # the right reversion when we try to burn these tokens on-chain. This should be a separate
+        # test case that runs *automatically*.
         self.diamond_terminus.create_pool_v1(100, True, True, {"from": controller})
         pool_id = self.diamond_terminus.total_pools()
         self.diamond_terminus.mint(
@@ -759,7 +766,7 @@ class TestPoolOperations(TerminusTestCase):
         operator_balance_0 = self.diamond_terminus.balance_of(operator.address, pool_id)
         user_balance_0 = self.diamond_terminus.balance_of(user.address, pool_id)
 
-        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
 
         with self.assertRaises(VirtualMachineError):
             self.diamond_terminus.mint(
@@ -811,7 +818,7 @@ class TestPoolOperations(TerminusTestCase):
 
         self.diamond_terminus.approve_for_pool(pool_id, operator, {"from": accounts[1]})
 
-        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
 
         self.diamond_terminus.mint(
             controller.address, pool_id, 1, "", {"from": operator}
@@ -848,13 +855,13 @@ class TestPoolOperations(TerminusTestCase):
                 pool_id, operator, {"from": operator}
             )
 
-        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
 
         self.diamond_terminus.unapprove_for_pool(
             pool_id, operator, {"from": controller}
         )
 
-        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator.address))
 
         with self.assertRaises(VirtualMachineError):
             self.diamond_terminus.mint(

--- a/dao/test_terminus.py
+++ b/dao/test_terminus.py
@@ -1,3 +1,4 @@
+from re import I
 from typing import List
 import unittest
 
@@ -736,6 +737,167 @@ class TestPoolOperations(TerminusTestCase):
         )
         self.assertEqual(final_pool_supply, initial_pool_supply)
         self.assertEqual(final_owner_balance, initial_owner_balance)
+
+    def test_pool_approval(self):
+        controller = accounts[1]
+        operator = accounts[2]
+        user = accounts[3]
+
+        self.diamond_terminus.create_pool_v1(100, True, True, {"from": controller})
+        pool_id = self.diamond_terminus.total_pools()
+        self.diamond_terminus.mint(
+            controller.address, pool_id, 5, "", {"from": controller}
+        )
+        self.diamond_terminus.mint(
+            operator.address, pool_id, 5, "", {"from": controller}
+        )
+        self.diamond_terminus.mint(user.address, pool_id, 5, "", {"from": controller})
+
+        controller_balance_0 = self.diamond_terminus.balance_of(
+            controller.address, pool_id
+        )
+        operator_balance_0 = self.diamond_terminus.balance_of(operator.address, pool_id)
+        user_balance_0 = self.diamond_terminus.balance_of(user.address, pool_id)
+
+        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.mint(
+                controller.address, pool_id, 1, "", {"from": operator}
+            )
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.mint(
+                operator.address, pool_id, 1, "", {"from": operator}
+            )
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.mint(user.address, pool_id, 1, "", {"from": operator})
+
+        controller_balance_1 = self.diamond_terminus.balance_of(
+            controller.address, pool_id
+        )
+        operator_balance_1 = self.diamond_terminus.balance_of(operator.address, pool_id)
+        user_balance_1 = self.diamond_terminus.balance_of(user.address, pool_id)
+
+        self.assertEqual(controller_balance_1, controller_balance_0)
+        self.assertEqual(operator_balance_1, operator_balance_0)
+        self.assertEqual(user_balance_1, user_balance_0)
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.burn(
+                controller.address, pool_id, 1, {"from": operator}
+            )
+
+        self.diamond_terminus.burn(operator.address, pool_id, 1, {"from": operator})
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.burn(user.address, pool_id, 1, {"from": operator})
+
+        controller_balance_2 = self.diamond_terminus.balance_of(
+            controller.address, pool_id
+        )
+        operator_balance_2 = self.diamond_terminus.balance_of(operator.address, pool_id)
+        user_balance_2 = self.diamond_terminus.balance_of(user.address, pool_id)
+
+        self.assertEqual(controller_balance_2, controller_balance_1)
+        self.assertEqual(operator_balance_2, operator_balance_1 - 1)
+        self.assertEqual(user_balance_2, user_balance_1)
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.approve_for_pool(
+                pool_id, operator, {"from": operator}
+            )
+
+        self.diamond_terminus.approve_for_pool(pool_id, operator, {"from": accounts[1]})
+
+        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+
+        self.diamond_terminus.mint(
+            controller.address, pool_id, 1, "", {"from": operator}
+        )
+        self.diamond_terminus.mint(operator.address, pool_id, 1, "", {"from": operator})
+        self.diamond_terminus.mint(user.address, pool_id, 1, "", {"from": operator})
+
+        controller_balance_3 = self.diamond_terminus.balance_of(
+            controller.address, pool_id
+        )
+        operator_balance_3 = self.diamond_terminus.balance_of(operator.address, pool_id)
+        user_balance_3 = self.diamond_terminus.balance_of(user.address, pool_id)
+
+        self.assertEqual(controller_balance_3, controller_balance_2 + 1)
+        self.assertEqual(operator_balance_3, operator_balance_2 + 1)
+        self.assertEqual(user_balance_3, user_balance_2 + 1)
+
+        self.diamond_terminus.burn(controller.address, pool_id, 1, {"from": operator})
+        self.diamond_terminus.burn(operator.address, pool_id, 1, {"from": operator})
+        self.diamond_terminus.burn(user.address, pool_id, 1, {"from": operator})
+
+        controller_balance_4 = self.diamond_terminus.balance_of(
+            controller.address, pool_id
+        )
+        operator_balance_4 = self.diamond_terminus.balance_of(operator.address, pool_id)
+        user_balance_4 = self.diamond_terminus.balance_of(user.address, pool_id)
+
+        self.assertEqual(controller_balance_4, controller_balance_3 - 1)
+        self.assertEqual(operator_balance_4, operator_balance_3 - 1)
+        self.assertEqual(user_balance_4, user_balance_3 - 1)
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.unapprove_for_pool(
+                pool_id, operator, {"from": operator}
+            )
+
+        self.assertTrue(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+
+        self.diamond_terminus.unapprove_for_pool(
+            pool_id, operator, {"from": controller}
+        )
+
+        self.assertFalse(self.diamond_terminus.is_approved_for_pool(pool_id, operator))
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.mint(
+                controller.address, pool_id, 1, "", {"from": operator}
+            )
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.mint(
+                operator.address, pool_id, 1, "", {"from": operator}
+            )
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.mint(user.address, pool_id, 1, "", {"from": operator})
+
+        controller_balance_5 = self.diamond_terminus.balance_of(
+            controller.address, pool_id
+        )
+        operator_balance_5 = self.diamond_terminus.balance_of(operator.address, pool_id)
+        user_balance_5 = self.diamond_terminus.balance_of(user.address, pool_id)
+
+        self.assertEqual(controller_balance_5, controller_balance_4)
+        self.assertEqual(operator_balance_5, operator_balance_4)
+        self.assertEqual(user_balance_5, user_balance_4)
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.burn(
+                controller.address, pool_id, 1, {"from": operator}
+            )
+
+        self.diamond_terminus.burn(operator.address, pool_id, 1, {"from": operator})
+
+        with self.assertRaises(VirtualMachineError):
+            self.diamond_terminus.burn(user.address, pool_id, 1, {"from": operator})
+
+        controller_balance_6 = self.diamond_terminus.balance_of(
+            controller.address, pool_id
+        )
+        operator_balance_6 = self.diamond_terminus.balance_of(operator.address, pool_id)
+        user_balance_6 = self.diamond_terminus.balance_of(user.address, pool_id)
+
+        self.assertEqual(controller_balance_6, controller_balance_5)
+        self.assertEqual(operator_balance_6, operator_balance_5 - 1)
+        self.assertEqual(user_balance_6, user_balance_5)
 
 
 class TestCreatePoolV1(TestPoolOperations):

--- a/dao/test_terminus_controller.py
+++ b/dao/test_terminus_controller.py
@@ -167,6 +167,30 @@ class TestTerminusController(unittest.TestCase):
         )
         self.assertEqual(self.terminus.balance_of(accounts[4], new_pool_id), 1)
 
+    def test_pool_approval(self):
+        controller = accounts[0]
+        operator = accounts[2]
+
+        self.assertFalse(
+            self.terminus.is_approved_for_pool(self.main_pool_id, operator.address)
+        )
+
+        self.terminus_controller.approve_for_pool(
+            self.main_pool_id, operator.address, {"from": controller}
+        )
+
+        self.assertTrue(
+            self.terminus.is_approved_for_pool(self.main_pool_id, operator.address)
+        )
+
+        self.terminus_controller.unapprove_for_pool(
+            self.main_pool_id, operator.address, {"from": controller}
+        )
+
+        self.assertFalse(
+            self.terminus.is_approved_for_pool(self.main_pool_id, operator.address)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

1. Approved addresses can mint and burn
2. Added `unapproveForPool`
3. `TerminusController` now supports `approveForPool`, `unapproveForPool`, `isApprovedForPool`.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

`./test.sh`

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
