### PR TITLE
Fix for the "mintBatch" exploit

### DIFF
--- a/contracts/terminus/ERC1155WithTerminusStorage.sol
+++ b/contracts/terminus/ERC1155WithTerminusStorage.sol
@@ -386,18 +386,15 @@ contract ERC1155WithTerminusStorage is
 
         LibTerminus.TerminusStorage storage ts = LibTerminus.terminusStorage();
 
-        for (uint256 i = 0; i < ids.length; i++) {
-            require(
-                ts.poolSupply[ids[i]] + amounts[i] <= ts.poolCapacity[ids[i]],
-                "ERC1155WithTerminusStorage: _mintBatch -- Minted tokens would exceed pool capacity"
-            );
-        }
-
         address operator = _msgSender();
 
         _beforeTokenTransfer(operator, address(0), to, ids, amounts, data);
 
         for (uint256 i = 0; i < ids.length; i++) {
+            require(
+                ts.poolSupply[ids[i]] + amounts[i] <= ts.poolCapacity[ids[i]],
+                "ERC1155WithTerminusStorage: _mintBatch -- Minted tokens would exceed pool capacity"
+            );
             ts.poolSupply[ids[i]] += amounts[i];
             ts.poolBalances[ids[i]][to] += amounts[i];
         }

--- a/dao/test_terminus.py
+++ b/dao/test_terminus.py
@@ -353,6 +353,27 @@ class TestPoolOperations(TerminusTestCase):
         supply = self.diamond_terminus.terminus_pool_supply(pool_id)
         self.assertEqual(supply, 0)
 
+    def test_mint_batch_fails_if_it_exceeds_capacity_one_at_a_time(self):
+        capacity = 10
+        self.diamond_terminus.create_pool_v1(
+            capacity, True, True, {"from": accounts[1]}
+        )
+        pool_id = self.diamond_terminus.total_pools()
+        with self.assertRaises(Exception):
+            self.diamond_terminus.mint_batch(
+                accounts[2].address,
+                pool_i_ds=[pool_id for _ in range(capacity + 1)],
+                amounts=[1 for _ in range(capacity + 1)],
+                data=b"",
+                transaction_config={"from": accounts[1]},
+            )
+
+        balance = self.diamond_terminus.balance_of(accounts[2].address, pool_id)
+        self.assertEqual(balance, 0)
+
+        supply = self.diamond_terminus.terminus_pool_supply(pool_id)
+        self.assertEqual(supply, 0)
+
     def test_pool_mint_batch(self):
         pool_id = self.diamond_terminus.total_pools()
         target_accounts = [account.address for account in accounts[:5]]

--- a/dao/test_terminus.py
+++ b/dao/test_terminus.py
@@ -333,12 +333,16 @@ class TestPoolOperations(TerminusTestCase):
         )
 
     def test_mint_batch_fails_if_it_exceeds_capacity(self):
+        capacity = 10
+        self.diamond_terminus.create_pool_v1(
+            capacity, True, True, {"from": accounts[1]}
+        )
         pool_id = self.diamond_terminus.total_pools()
         with self.assertRaises(Exception):
             self.diamond_terminus.mint_batch(
                 accounts[2].address,
-                pool_i_ds=[pool_id],
-                amounts=[11],
+                pool_i_ds=[pool_id, pool_id],
+                amounts=[int(capacity / 2) + 1, int(capacity / 2) + 1],
                 data=b"",
                 transaction_config={"from": accounts[1]},
             )


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Before this fix, a pool controller (or authorized party) could bypass the pool capacity bound by passing the same pool ID into `mintBatch` multiple times.

This bug was caught by [Hacken.io](https://hacken.io/) auditors.

This PR fixes the issue.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

```bash
./test.sh dao.test_terminus
```

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
