### PR TITLE
Mint badges from file

### DIFF
--- a/scripts/mint_badge.py
+++ b/scripts/mint_badge.py
@@ -26,13 +26,24 @@ parser.add_argument(
     help="ID of Terminus pool representing the badge",
 )
 parser.add_argument(
-    "--recipients", nargs="+", help="Addresses that badge should be minted to"
+    "--recipients", nargs="*", help="Addresses that badge should be minted to"
+)
+parser.add_argument(
+    "--recipients-file",
+    type=argparse.FileType("r"),
+    help="(Optional) File containing addresses to mint badges to, one address per line. The addresses in this file are added to the addresses passed with the --recipients argument.",
 )
 parser.add_argument(
     "-y",
     "--yes",
     action="store_true",
     help="Set this flag to signal y on all confirmation prompts",
+)
+parser.add_argument(
+    "--batch-size",
+    type=int,
+    default=200,
+    help="Number of recipients to mint badges to per transaction.",
 )
 
 args = parser.parse_args()
@@ -42,36 +53,46 @@ if args.address is None:
         "Please specify the address of a Terminus contract using the --address argument."
     )
 
-if len(args.recipients) > 200:
-    raise ValueError("This script can process at most 200 recipients at a time.")
+if args.batch_size > 200:
+    raise ValueError("This script can process at most 200 recipients per batch.")
 
 network.connect(args.network)
 
 recipients = list(set(args.recipients))
 
+batches = []
+for i in range(0, len(recipients), args.batch_size):
+    batches.append(recipients[i : i + args.batch_size])
+
 terminus = TerminusFacet.TerminusFacet(args.address)
 pool_uri = terminus.uri(args.pool_id)
-balances = zip(
-    recipients,
-    terminus.balance_of_batch(recipients, [args.pool_id for _ in recipients]),
-)
-
-valid_recipients = [recipient for recipient, balance in balances if balance == 0]
 
 print(
     f"Badge information -- Terminus address: {args.address}, pool ID: {args.pool_id}, pool URI: {pool_uri}"
 )
-print("\n- ".join(["Intended recipients:"] + valid_recipients))
 
-if not args.yes:
-    permission_check = input("Proceed? (y/N)")
-    if permission_check.strip().lower() != "y":
-        raise Exception("You did not wish to proceed")
+for i, batch in enumerate(batches):
+    balances = zip(
+        batch,
+        terminus.balance_of_batch(recipients, [args.pool_id for _ in recipients]),
+    )
 
-amounts = [1 for _ in valid_recipients]
-transaction_config = TerminusFacet.get_transaction_config(args)
-transaction_info = terminus.pool_mint_batch(
-    args.pool_id, valid_recipients, amounts, transaction_config
-)
+    valid_recipients = [recipient for recipient, balance in balances if balance == 0]
+    if not valid_recipients:
+        print("No valid recipients in this batch")
+        continue
 
-print(transaction_info)
+    print("\n- ".join([f"Batch {i} -- intended recipients:"] + valid_recipients))
+
+    if not args.yes:
+        permission_check = input("Proceed? (y/N)")
+        if permission_check.strip().lower() != "y":
+            raise Exception("You did not wish to proceed")
+
+    amounts = [1 for _ in valid_recipients]
+    transaction_config = TerminusFacet.get_transaction_config(args)
+    transaction_info = terminus.pool_mint_batch(
+        args.pool_id, valid_recipients, amounts, transaction_config
+    )
+
+    print(transaction_info)


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

This PR improves `scripts/mint_badge.py` in the following ways:

1. Caller can now specify a `--recipients-file` to read addresses from. Addresses are expected to be one per line.
2. The script can now handle multiple batches of recipients.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Tested locally.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

Resolves https://github.com/bugout-dev/ops/issues/7

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
